### PR TITLE
Support docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    sqlite3 && \
+    rm -rf /var/lib/apt/lists/*
+
+
+COPY pyproject.toml poetry.lock* /app/
+
+
+RUN pip install --no-cache-dir poetry
+
+
+RUN poetry install --no-root
+
+COPY . /app
+
+CMD ["poetry", "run", "python", "-m", "bot.__main__"]

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -3,7 +3,7 @@ import logging
 from telegram import Update
 from telegram.ext import Application
 
-from handlers import register_handlers
+from bot.handlers import register_handlers
 
 # Set up logging
 logging.basicConfig(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  bot:
+    build:
+      context: .
+    env_file:
+      - .env
+    volumes:
+      - database-data:/app/data
+
+volumes:
+  database-data:


### PR DESCRIPTION
Не хватает настройки прав для sqllite. При этом даже без докера не получается создать базу данных. 
Ошибка выглядит так:
```text
bot-1  |   File "/app/bot/database/database.py", line 72, in insert_user
bot-1  |     conn = sqlite3.connect(database_path)
bot-1  | sqlite3.OperationalError: unable to open database file
```

А еще нужно readme поправить.
Сейчас собирается вот так:
```bash
docker compose build && docker compose up
```
Нужно указать переменную окружения BOT_TOKEN в .env файле.
